### PR TITLE
Add server garbage collection as recommended for high-performance .NET

### DIFF
--- a/ServiceLoadTest/Framework/LoadDriverService/App.config
+++ b/ServiceLoadTest/Framework/LoadDriverService/App.config
@@ -3,4 +3,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
+  <runtime>
+    <!-- Server garbage collection is intended for server applications that need high throughput and scalability -->
+    <!-- https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals?view=netframework-4.7#workstation_and_server_garbage_collection -->
+    <gcServer enabled="true"/>
+  </runtime>
 </configuration>

--- a/ServiceLoadTest/Framework/TestClient/App.config
+++ b/ServiceLoadTest/Framework/TestClient/App.config
@@ -43,6 +43,11 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
+  <runtime>
+    <!-- Server garbage collection is intended for server applications that need high throughput and scalability -->
+    <!-- https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals?view=netframework-4.7#workstation_and_server_garbage_collection -->
+    <gcServer enabled="true"/>
+  </runtime>
   <system.net>
     <connectionManagement>
       <add address="*" maxconnection="64" />

--- a/ServiceLoadTest/ServiceFabric/Actor/SFActor/App.config
+++ b/ServiceLoadTest/ServiceFabric/Actor/SFActor/App.config
@@ -3,4 +3,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
+  <runtime>
+    <!-- Server garbage collection is intended for server applications that need high throughput and scalability -->
+    <!-- https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals?view=netframework-4.7#workstation_and_server_garbage_collection -->
+    <gcServer enabled="true"/>
+  </runtime>
 </configuration>

--- a/ServiceLoadTest/ServiceFabric/Dictionary/SFDictionaryService/App.config
+++ b/ServiceLoadTest/ServiceFabric/Dictionary/SFDictionaryService/App.config
@@ -3,4 +3,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
+  <runtime>
+    <!-- Server garbage collection is intended for server applications that need high throughput and scalability -->
+    <!-- https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals?view=netframework-4.7#workstation_and_server_garbage_collection -->
+    <gcServer enabled="true"/>
+  </runtime>
 </configuration>


### PR DESCRIPTION
Add server garbage collection as recommended for high-performance .NET applications. See: https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals?view=netframework-4.7#workstation_and_server_garbage_collection